### PR TITLE
Fix undefined 'text' when call showLoading() without title

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -9,10 +9,11 @@ import {
   Dimensions,
   TouchableOpacity,
   Easing,
-  Platform
+  Platform,
+  StatusBar,
 } from "react-native";
 
-const STATUS_BAR_PADDING = Platform.OS === "ios" ? 15 : 0;
+const STATUS_BAR_PADDING = Platform.OS === "ios" ? 15 : StatusBar.currentHeight;
 const NOTIFICATION_PADDING = 15;
 const NOTIFICATION_HEIGHT = 80 + STATUS_BAR_PADDING;
 const ANIMATION_DURATION = 200;

--- a/src/index.js
+++ b/src/index.js
@@ -242,7 +242,7 @@ export function showLoading(payload) {
   }
   else if (typeof payload === "string") {
     currentLoading.title = null;
-    currentLoading.text = text;
+    currentLoading.text = payload;
     currentLoading.params = {};
   }
 


### PR DESCRIPTION
Fix undefined variable 'text' error when call showLoading('message') without title.